### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ concurrency:
 jobs:
   shellcheck:
     name: Test
+    permissions:
+      contents: read
     uses: ./.github/workflows/check.yml
   build:
     name: Build


### PR DESCRIPTION
Potential fix for [https://github.com/anubissbe/windows/security/code-scanning/2](https://github.com/anubissbe/windows/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the `shellcheck` job. Based on the job's name and usage, it likely only requires read access to the repository contents. Therefore, the `permissions` block should specify `contents: read`. This ensures the job operates with the least privilege necessary.

The changes will be made to the `.github/workflows/build.yml` file:
1. Add a `permissions` block under the `shellcheck` job.
2. Set `contents: read` as the permission level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
